### PR TITLE
Add alias function Load and Store, Expose Move function from list.List

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -9,6 +9,7 @@ package orderedmap
 
 import (
 	"container/list"
+	"fmt"
 )
 
 type Pair struct {
@@ -39,6 +40,9 @@ func (om *OrderedMap) Get(key interface{}) (interface{}, bool) {
 	}
 	return nil, false
 }
+func (om *OrderedMap) Load(key interface{}) (interface{}, bool) {
+	return om.Get(key)
+}
 
 // GetPair looks for the given key, and returns the pair associated with it,
 // or nil if not found. The Pair struct can then be used to iterate over the ordered map
@@ -65,6 +69,9 @@ func (om *OrderedMap) Set(key interface{}, value interface{}) (interface{}, bool
 
 	return nil, false
 }
+func (om *OrderedMap) Store(key interface{}, value interface{}) (interface{}, bool) {
+	return om.Set(key, value)
+}
 
 // Delete removes the key-value pair, and returns what `Get` would have returned
 // on that key prior to the call to `Delete`.
@@ -74,7 +81,6 @@ func (om *OrderedMap) Delete(key interface{}) (interface{}, bool) {
 		delete(om.pairs, key)
 		return pair.Value, true
 	}
-
 	return nil, false
 }
 
@@ -112,4 +118,55 @@ func listElementToPair(element *list.Element) *Pair {
 		return nil
 	}
 	return element.Value.(*Pair)
+}
+
+func (om *OrderedMap) MoveAfter(key interface{}, mark_key interface{}) error {
+	var e, mark *list.Element
+	if pair, present := om.pairs[key]; present {
+		e = pair.element
+	} else {
+		return fmt.Errorf("error: key %v not found", key)
+	}
+	if pair, present := om.pairs[mark_key]; present {
+		mark = pair.element
+	} else {
+		return fmt.Errorf("error: mark_key %v not found", mark_key)
+	}
+	om.list.MoveAfter(e, mark)
+	return nil
+}
+func (om *OrderedMap) MoveBefore(key interface{}, mark_key interface{}) error {
+	var e, mark *list.Element
+	if pair, present := om.pairs[key]; present {
+		e = pair.element
+	} else {
+		return fmt.Errorf("error: key %v not found", key)
+	}
+	if pair, present := om.pairs[mark_key]; present {
+		mark = pair.element
+	} else {
+		return fmt.Errorf("error: mark_key %v not found", mark_key)
+	}
+	om.list.MoveBefore(e, mark)
+	return nil
+}
+func (om *OrderedMap) MoveToBack(key interface{}) error {
+	var e *list.Element
+	if pair, present := om.pairs[key]; present {
+		e = pair.element
+	} else {
+		return fmt.Errorf("error: key %v not found", key)
+	}
+	om.list.MoveToBack(e)
+	return nil
+}
+func (om *OrderedMap) MoveToFront(key interface{}) error {
+	var e *list.Element
+	if pair, present := om.pairs[key]; present {
+		e = pair.element
+	} else {
+		return fmt.Errorf("error: key %v not found", key)
+	}
+	om.list.MoveToFront(e)
+	return nil
 }

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -273,3 +273,45 @@ func randomHexString(t *testing.T, length int) string {
 
 	return hex.EncodeToString(randBytes)
 }
+
+func TestMove(t *testing.T) {
+	om := New()
+	om.Set("1", "bar")
+	om.Set(2, 28)
+	om.Set(3, 100)
+	om.Set("4", "baz")
+	om.Set(5, "28")
+	om.Set(6, "100")
+	om.Set("7", "baz")
+	om.Set("8", "baz")
+
+	var err error
+
+	err = om.MoveAfter(2, 3)
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]interface{}{"1", 3, 2, "4", 5, 6, "7", "8"},
+		[]interface{}{"bar", 100, 28, "baz", "28", "100", "baz", "baz"})
+
+	err = om.MoveBefore(6, "4")
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]interface{}{"1", 3, 2, 6, "4", 5, "7", "8"},
+		[]interface{}{"bar", 100, 28, "100", "baz", "28", "baz", "baz"})
+
+	err = om.MoveToBack(3)
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]interface{}{"1", 2, 6, "4", 5, "7", "8", 3},
+		[]interface{}{"bar", 28, "100", "baz", "28", "baz", "baz", 100})
+
+	err = om.MoveToFront(5)
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]interface{}{5, "1", 2, 6, "4", "7", "8", 3},
+		[]interface{}{"28", "bar", 28, "100", "baz", "baz", "baz", 100})
+
+	err = om.MoveToFront(100)
+	assert.NotEqual(t, err, nil)
+
+}


### PR DESCRIPTION
1. Add alias function Load and Store
sync.Map uses Load/Store but this uses Get() and Set(), so I added alias to make the API more consistency.

2. Expose ```Move*``` function from list.List so that users cam move the order of the element in orderedMap directly.
```go
	om := New()
	om.Set("1", "bar")
	om.Set(2, 28)
	om.Set(3, 100)
	om.Set("4", "baz")
	om.Set(5, "28")
	om.Set(6, "100")
	om.Set("7", "baz")
	om.Set("8", "baz")

	om.MoveAfter(2, 3)
	om.MoveBefore(6, "4")
        om.MoveToBack(3)
	om.MoveToFront(5)
```