### PR TITLE
Function Request - Copy, Reverse, First, Front, Back, Last

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -33,13 +33,36 @@ func New[K comparable, V any]() *OrderedMap[K, V] {
 	}
 }
 
+// Copy creates a new OrderedMap that has the same mappings as the current map.
+func (om *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
+	ret := &OrderedMap[K, V]{
+		pairs: make(map[K]*Pair[K, V]),
+		list:  list.New[*Pair[K, V]](),
+	}
+	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+		ret.Set(pair.Key, pair.Value)
+	}
+	return ret
+}
+
+// Reverse reverses the order of the mappings within a map.
+func (om *OrderedMap[K, V]) Reverse() {
+	curr := om.list.Front()
+	prev, next := curr, curr.Next()
+	for curr != nil {
+		next = curr.Next()
+		om.list.MoveBefore(curr, prev)
+		prev = curr
+		curr = next
+	}
+}
+
 // Get looks for the given key, and returns the value associated with it,
 // or V's nil value if not found. The boolean it returns says whether the key is present in the map.
 func (om *OrderedMap[K, V]) Get(key K) (val V, present bool) {
 	if pair, present := om.pairs[key]; present {
 		return pair.Value, true
 	}
-
 	return
 }
 
@@ -102,10 +125,30 @@ func (om *OrderedMap[K, V]) Oldest() *Pair[K, V] {
 	return listElementToPair(om.list.Front())
 }
 
+// First is an alias for Oldest, as sometimes it can be more clear.
+func (om *OrderedMap[K, V]) First() *Pair[K, V] {
+	return listElementToPair(om.list.Front())
+}
+
+// Front is an alias for Oldest, as sometimes it can be more clear.
+func (om *OrderedMap[K, V]) Front() *Pair[K, V] {
+	return listElementToPair(om.list.Front())
+}
+
 // Newest returns a pointer to the newest pair. It's meant to be used to iterate on the ordered map's
 // pairs from the newest to the oldest, e.g.:
 // for pair := orderedMap.Oldest(); pair != nil; pair = pair.Next() { fmt.Printf("%v => %v\n", pair.Key, pair.Value) }
 func (om *OrderedMap[K, V]) Newest() *Pair[K, V] {
+	return listElementToPair(om.list.Back())
+}
+
+// Last is an alias for Newest, as sometimes it can be more clear.
+func (om *OrderedMap[K, V]) Last() *Pair[K, V] {
+	return listElementToPair(om.list.Back())
+}
+
+// Back is an alias for Newest, as sometimes it can be more clear.
+func (om *OrderedMap[K, V]) Back() *Pair[K, V] {
 	return listElementToPair(om.list.Back())
 }
 

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -102,16 +102,31 @@ func TestBasicFeatures(t *testing.T) {
 
 	// check iterations again
 	i = 0
-	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+	for pair := om.First(); pair != nil; pair = pair.Next() {
 		assert.Equal(t, i, pair.Key)
 		assert.Equal(t, 4*i, pair.Value)
 		i += 2
 	}
 	i = 2 * ((n - 1) / 2)
-	for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+	for pair := om.Last(); pair != nil; pair = pair.Prev() {
 		assert.Equal(t, i, pair.Key)
 		assert.Equal(t, 4*i, pair.Value)
 		i -= 2
+	}
+
+	// check copying
+	com := om.Copy()
+	for np, cp := om.Front(), com.Front(); np != nil; np, cp = np.Next(), cp.Next() {
+		assert.Equal(t, np.Key, cp.Key)
+		assert.Equal(t, np.Value, cp.Value)
+	}
+
+	// check reversing
+	rom := om.Copy()
+	rom.Reverse()
+	for np, rp := om.Front(), rom.Back(); np != nil; np, rp = np.Next(), rp.Prev() {
+		assert.Equal(t, np.Key, rp.Key)
+		assert.Equal(t, np.Value, rp.Value)
 	}
 }
 


### PR DESCRIPTION
This closes the function request issue #10 that I created.

Additions:
* Copy(): Produce a copy of a OrderedMap object
* Reverse(): Reverse a certain OrderedMap object
* First() and Front(): Alias for Oldest
* Last() and Back(): Alias for Newest
* Tests for Copy and Reverse

Notes:
* Copy could technically be optimized via some memory library but this should be performant enough without causing too much overhead.
* Reverse could be more readable if the generic list library implemented a reverse function, nevertheless its just as efficient.
* I decided against Keys() and Values() at least for now due to mis-interruptions and limited use cases.
* You might notice that First, Front, Last, and Back are technically not aliases as they do not call Oldest and Newest. I leaned on the side of efficiency (bypassing the function call) because the definition is a one-line / straightforward.

I am happy to make any changes upon requests.