### PR TITLE
Fuzz un/marshall-ing methods after #16

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,90 @@
+package orderedmap
+
+// Adapted from https://github.com/dvyukov/go-fuzz-corpus/blob/c42c1b2/json/json.go
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/dvyukov/go-fuzz-corpus/fuzz"
+)
+
+func FuzzMarshalling(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		for _, ctor := range []func() any{
+			func() any { return nil },
+			func() any { return new([]any) },
+			func() any { return &OrderedMap[string, string]{} },
+			func() any { return &OrderedMap[string, any]{} },
+			func() any { return new(S) },
+		} {
+			v := ctor()
+			if json.Unmarshal(data, v) != nil {
+				continue
+			}
+			if s, ok := v.(*S); ok {
+				if len(s.P) == 0 {
+					s.P = []byte(`""`)
+				}
+			}
+			data1, err := json.Marshal(v)
+			if err != nil {
+				panic(err)
+			}
+			v1 := ctor()
+			if json.Unmarshal(data1, v1) != nil {
+				continue
+			}
+			if s, ok := v.(*S); ok {
+				// Some additional escaping happens with P.
+				s.P = nil
+				v1.(*S).P = nil
+			}
+			if !fuzz.DeepEqual(v, v1) {
+				fmt.Printf("v0: %#v\n", v)
+				fmt.Printf("v1: %#v\n", v1)
+				panic("not equal")
+			}
+		}
+	})
+}
+
+type S struct {
+	A int    `json:",omitempty"`
+	B string `json:"B1,omitempty"`
+	C float64
+	D bool
+	E uint8
+	F []byte
+	G any
+	H OrderedMap[string, any]
+	I OrderedMap[string, string]
+	J []any
+	K []string
+	L S1
+	M *S1
+	N *int
+	O **int
+	P json.RawMessage
+	Q Marshaller
+	R int `json:"-"`
+	S int `json:",string"`
+}
+
+type S1 struct {
+	A int
+	B string
+}
+
+type Marshaller struct {
+	v string
+}
+
+func (m *Marshaller) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.v)
+}
+
+func (m *Marshaller) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &m.v)
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -5,9 +5,8 @@ package orderedmap
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
-
-	"github.com/dvyukov/go-fuzz-corpus/fuzz"
 )
 
 func FuzzMarshalling(f *testing.F) {
@@ -43,7 +42,7 @@ func FuzzMarshalling(f *testing.F) {
 				v1.(*S).P = nil
 			}
 
-			if !fuzz.DeepEqual(v, v1) {
+			if !reflect.DeepEqual(v, v1) {
 				// Skip false positives due to linked list initialization
 				switch v := v.(type) {
 				case *OrderedMap[string, string]:

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,12 @@ go 1.18
 require (
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/buger/jsonparser v1.1.1
-	github.com/davecgh/go-spew v1.1.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/stretchr/testify v1.6.1
 )
 
 require (
-	github.com/dvyukov/go-fuzz-corpus v0.0.0-20190920191254-c42c1b2914c7 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/dvyukov/go-fuzz-corpus v0.0.0-20190920191254-c42c1b2914c7 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,9 +4,6 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dvyukov/go-fuzz-corpus v0.0.0-20190920191254-c42c1b2914c7 h1:dECcCtiFwubOBYviX4zj9ggx9ucw2lLEGlU3O+Q7tuk=
-github.com/dvyukov/go-fuzz-corpus v0.0.0-20190920191254-c42c1b2914c7/go.mod h1:aSQy4yPbyjNrXv8ANgj9BQacfss3bbmXTon1mFcwc1k=
-github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dvyukov/go-fuzz-corpus v0.0.0-20190920191254-c42c1b2914c7 h1:dECcCtiFwubOBYviX4zj9ggx9ucw2lLEGlU3O+Q7tuk=
+github.com/dvyukov/go-fuzz-corpus v0.0.0-20190920191254-c42c1b2914c7/go.mod h1:aSQy4yPbyjNrXv8ANgj9BQacfss3bbmXTon1mFcwc1k=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/testdata/fuzz/FuzzMarshalling/8093511184ad3e258aa13b957e75ff26c7fae64672dae0c0bc0a9fa5b61a05e7
+++ b/testdata/fuzz/FuzzMarshalling/8093511184ad3e258aa13b957e75ff26c7fae64672dae0c0bc0a9fa5b61a05e7
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{}")


### PR DESCRIPTION
Run fuzzing with `go test  -fuzz=. -fuzztime=10s ./...`

```
--- FAIL: FuzzMarshalling (0.00s)
    --- FAIL: FuzzMarshalling/8093511184ad3e258aa13b957e75ff26c7fae64672dae0c0bc0a9fa5b61a05e7 (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x610968]

goroutine 7 [running]:
testing.tRunner.func1.2({0x63f4e0, 0x84be00})
	/snap/go/10008/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
	/snap/go/10008/src/testing/testing.go:1399 +0x39f
panic({0x63f4e0, 0x84be00})
	/snap/go/10008/src/runtime/panic.go:884 +0x212
encoding/json.(*encodeState).marshal.func1()
	/snap/go/10008/src/encoding/json/encode.go:327 +0x6e
panic({0x63f4e0, 0x84be00})
	/snap/go/10008/src/runtime/panic.go:884 +0x212
github.com/bahlo/generic-list-go.(*List[...]).Front(...)
	/home/pete/wefwefwef/go/pkg/mod/github.com/bahlo/generic-list-go@v0.2.0/list.go:70
github.com/wk8/go-ordered-map/v2.(*OrderedMap[...]).Oldest(...)
	/home/pete/wefwefwef/go-ordered-map.git/orderedmap.go:102
github.com/wk8/go-ordered-map/v2.(*OrderedMap[...]).MarshalJSON(0xc000069270)
	/home/pete/wefwefwef/go-ordered-map.git/json.go:23 +0x88
encoding/json.marshalerEncoder(0xc00015e600, {0x66f160?, 0xc000069270?, 0x30?}, {0x8?, 0x31?})
	/snap/go/10008/src/encoding/json/encode.go:478 +0xbe
encoding/json.(*encodeState).reflectValue(0x0?, {0x66f160?, 0xc000069270?, 0x40ef87?}, {0x78?, 0x0?})
	/snap/go/10008/src/encoding/json/encode.go:359 +0x78
encoding/json.(*encodeState).marshal(0x88?, {0x66f160?, 0xc000069270?}, {0x80?, 0xf6?})
	/snap/go/10008/src/encoding/json/encode.go:331 +0xfa
encoding/json.Marshal({0x66f160, 0xc000069270})
	/snap/go/10008/src/encoding/json/encode.go:160 +0x45
github.com/wk8/go-ordered-map/v2.FuzzMarshalling.func1(0x0?, {0xc00001cc60, 0x2, 0x8})
	/home/pete/wefwefwef/go-ordered-map.git/fuzz_test.go:31 +0x1b4
reflect.Value.call({0x634b40?, 0x6ab2a8?, 0x13?}, {0x67d806, 0x4}, {0xc0001097d0, 0x2, 0x2?})
	/snap/go/10008/src/reflect/value.go:584 +0x8c5
reflect.Value.Call({0x634b40?, 0x6ab2a8?, 0x51b?}, {0xc0001097d0?, 0x7ee0d8?, 0x825900?})
	/snap/go/10008/src/reflect/value.go:368 +0xbc
testing.(*F).Fuzz.func1.1(0x0?)
	/snap/go/10008/src/testing/fuzz.go:337 +0x231
testing.tRunner(0xc000134b60, 0xc000136090)
	/snap/go/10008/src/testing/testing.go:1446 +0x10b
created by testing.(*F).Fuzz.func1
	/snap/go/10008/src/testing/fuzz.go:324 +0x5b9
exit status 2
FAIL	github.com/wk8/go-ordered-map/v2	0.006s
```