### PR TITLE
v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 2.1.2 - Dec 10th 2022
+* Allowing to pass options to `New`, to give a capacity hint, or initial data
+* Allowing to deserialize nested ordered maps from JSON without having to explicitly instantiate them
+* Added the `AddPairs` method
+
 # 2.1.1 - Dec 9th 2022
 * Fixing a bug with JSON marshalling
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ func main() {
 }
 ```
 
+Also worth noting that you can provision ordered maps with a capacity hint, as you would do by passing an optional hint to `make(map[K]V, capacity`):
+```go
+om := orderedmap.New[int, *myStruct](28)
+```
+
+You can also pass in some initial data to store in the map:
+```go
+om := orderedmap.New[int, string](orderedmap.WithInitialData[int, string](
+	orderedmap.Pair[int, string]{
+		Key:   12,
+		Value: "foo",
+	},
+	orderedmap.Pair[int, string]{
+		Key:   28,
+		Value: "bar",
+	},
+))
+```
+
 `OrderedMap`s also support JSON serialization/deserialization, and preserves order:
 
 ```go

--- a/json.go
+++ b/json.go
@@ -84,6 +84,10 @@ func dumpWriter(writer *jwriter.Writer) ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (om *OrderedMap[K, V]) UnmarshalJSON(data []byte) error {
+	if om.list == nil {
+		om.initialize(0)
+	}
+
 	return jsonparser.ObjectEach(
 		data,
 		func(keyData []byte, valueData []byte, dataType jsonparser.ValueType, offset int) error {

--- a/test_utils.go
+++ b/test_utils.go
@@ -39,11 +39,11 @@ func assertOrderedPairsEqualFromOldest[K comparable, V any](
 	t.Helper()
 
 	if assert.Equal(t, len(expectedKeys), len(expectedValues)) && assert.Equal(t, len(expectedKeys), orderedMap.Len()) {
-		i := orderedMap.Len() - 1
-		for pair := orderedMap.Newest(); pair != nil; pair = pair.Prev() {
+		i := 0
+		for pair := orderedMap.Oldest(); pair != nil; pair = pair.Next() {
 			assert.Equal(t, expectedKeys[i], pair.Key)
 			assert.Equal(t, expectedValues[i], pair.Value)
-			i--
+			i++
 		}
 	}
 }


### PR DESCRIPTION
* Allowing to pass options to `New`, to give a capacity hint, or initial data
* Allowing to deserialize nested ordered maps from JSON without having to explicitly instantiate them
* Added the `AddPairs` method
* tests on all of the above