### PR TITLE
Add default handling for typed string key for json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/wk8/go-ordered-map/v2.svg)](https://pkg.go.dev/github.com/wk8/go-ordered-map/v2)
 [![Build Status](https://circleci.com/gh/wk8/go-ordered-map.svg?style=svg)](https://app.circleci.com/pipelines/github/wk8/go-ordered-map)
 
-# Goland Ordered Maps
+# Golang Ordered Maps
 
 Same as regular maps, but also remembers the order in which keys were inserted, akin to [Python's `collections.OrderedDict`s](https://docs.python.org/3.7/library/collections.html#ordereddict-objects).
 

--- a/json_test.go
+++ b/json_test.go
@@ -65,6 +65,17 @@ func TestMarshalJSON(t *testing.T) {
 		assert.Equal(t, `{"test":"bar","abc":true}`, string(b))
 	})
 
+	t.Run("typed string key", func(t *testing.T) {
+		type myString string
+		om := New[myString, any]()
+		om.Set("test", "bar")
+		om.Set("abc", true)
+
+		b, err := json.Marshal(om)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"test":"bar","abc":true}`, string(b))
+	})
+
 	t.Run("TextMarshaller key", func(t *testing.T) {
 		om := New[marshallable, any]()
 		om.Set(marshallable(1), "bar")
@@ -104,6 +115,17 @@ func TestUnmarshallJSON(t *testing.T) {
 
 		assertOrderedPairsEqual(t, om,
 			[]string{"test", "abc"},
+			[]any{"bar", true})
+	})
+
+	t.Run("typed string key", func(t *testing.T) {
+		data := `{"test":"bar","abc":true}`
+		type myString string
+		om := New[myString, any]()
+		require.NoError(t, json.Unmarshal([]byte(data), &om))
+
+		assertOrderedPairsEqual(t, om,
+			[]myString{"test", "abc"},
 			[]any{"bar", true})
 	})
 


### PR DESCRIPTION
The use case is, sometimes we might want to use a typed string key `type Foo string` instead of `string` to increase the descriptiveness of our API. This saves writing UnmarshalText for most cases yet still allows UnmarshalText to be written if direct string conversion is not desired.

I believe the use of reflect is necessary until type switch support `~`  https://github.com/golang/go/issues/45380#issuecomment-813003118

This is a backwards compatible change since it adds support for types previously returned error. There is also no performance impact on existing working code. There might be a risk that code used to return error could now panic, if someone more knowledgeable at the intersection of comparable types and reflect panic cases could review this code.

I though about extending this to the integer types, but it's not obvious what the desirable behavior is if the typed integer is an enum or stringer or decimal like time.Duration. If not right the first time, it would require an breaking change to fix. So it's probably better to wait until a pressing need appears.
