### PR TITLE
allow special character as keys

### DIFF
--- a/test_utils.go
+++ b/test_utils.go
@@ -26,8 +26,8 @@ func assertOrderedPairsEqualFromNewest[K comparable, V any](
 	if assert.Equal(t, len(expectedKeys), len(expectedValues)) && assert.Equal(t, len(expectedKeys), orderedMap.Len()) {
 		i := orderedMap.Len() - 1
 		for pair := orderedMap.Newest(); pair != nil; pair = pair.Prev() {
-			assert.Equal(t, expectedKeys[i], pair.Key)
-			assert.Equal(t, expectedValues[i], pair.Value)
+			assert.Equal(t, expectedKeys[i], pair.Key, "from newest index=%d on key", i)
+			assert.Equal(t, expectedValues[i], pair.Value, "from newest index=%d on value", i)
 			i--
 		}
 	}
@@ -41,8 +41,8 @@ func assertOrderedPairsEqualFromOldest[K comparable, V any](
 	if assert.Equal(t, len(expectedKeys), len(expectedValues)) && assert.Equal(t, len(expectedKeys), orderedMap.Len()) {
 		i := 0
 		for pair := orderedMap.Oldest(); pair != nil; pair = pair.Next() {
-			assert.Equal(t, expectedKeys[i], pair.Key)
-			assert.Equal(t, expectedValues[i], pair.Value)
+			assert.Equal(t, expectedKeys[i], pair.Key, "from oldest index=%d on key", i)
+			assert.Equal(t, expectedValues[i], pair.Value, "from oldest index=%d on value", i)
 			i++
 		}
 	}


### PR DESCRIPTION
The offending bug was in quoteString:
``` go 
func quoteString(data []byte) []byte {
	withQuotes := make([]byte, len(data)+2) //nolint:gomnd
	copy(withQuotes[1:], data)
	withQuotes[0] = '"'
	withQuotes[len(data)+1] = '"'
	return withQuotes
}
```

Which did not handle escaped characters. Since the key was quoted just to be un-quoted back to string, the code was refactored to set string type keys directly.

This bug fix should work for any valid utf-8 string. Round trapping will return the exact same string and byte compatible with the official Golang JSON library.

If a key string value is not valid utf-8, round trapping could change the key, I'm not sure what to do with that.