### PR TITLE
Add YAML serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It offers the following features:
 * allows iterating from newest or oldest keys indifferently, without memory copy, allowing to `break` the iteration, and in time linear to the number of keys iterated over rather than the total length of the ordered map
 * supports any generic types for both keys and values. If you're running go < 1.18, you can use [version 1](https://github.com/wk8/go-ordered-map/tree/v1) that takes and returns generic `interface{}`s instead of using generics
 * idiomatic API, akin to that of [`container/list`](https://golang.org/pkg/container/list)
+* support for JSON and YAML marshalling
 
 ## Documentation
 
@@ -128,6 +129,19 @@ data, err := json.Marshal(om)
 // deserialization
 om := orderedmap.New[string, string]() // or orderedmap.New[int, any](), or any type you expect
 err := json.Unmarshal(data, &om)
+...
+```
+
+Similarly, it also supports YAML serialization/deserialization using the yaml.v3 package, which also preserves order:
+
+```go
+// serialization
+data, err := yaml.Marshal(om)
+...
+
+// deserialization
+om := orderedmap.New[string, string]() // or orderedmap.New[int, any](), or any type you expect
+err := yaml.Unmarshal(data, &om)
 ...
 ```
 

--- a/json_test.go
+++ b/json_test.go
@@ -184,7 +184,7 @@ func TestUnmarshallJSON(t *testing.T) {
 	})
 }
 
-//const specialCharacters = "\\\\/\"\b\f\n\r\t\x00\uffff\ufffd世界\u007f\u00ff\U0010FFFF"
+// const specialCharacters = "\\\\/\"\b\f\n\r\t\x00\uffff\ufffd世界\u007f\u00ff\U0010FFFF"
 const specialCharacters = "\uffff\ufffd世界\u007f\u00ff\U0010FFFF"
 
 func TestJSONSpecialCharacters(t *testing.T) {
@@ -227,8 +227,8 @@ func TestJSONSpecialCharacters(t *testing.T) {
 
 // to test structs that have nested map fields
 type nestedMaps struct {
-	X int                                                               `json:"x"`
-	M *OrderedMap[string, []*OrderedMap[int, *OrderedMap[string, any]]] `json:"m"`
+	X int                                                               `json:"x" yaml:"x"`
+	M *OrderedMap[string, []*OrderedMap[int, *OrderedMap[string, any]]] `json:"m" yaml:"m"`
 }
 
 func TestJSONRoundTrip(t *testing.T) {

--- a/yaml.go
+++ b/yaml.go
@@ -1,0 +1,70 @@
+package orderedmap
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ yaml.Marshaler   = &OrderedMap[int, any]{}
+	_ yaml.Unmarshaler = &OrderedMap[int, any]{}
+)
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (om *OrderedMap[K, V]) MarshalYAML() (interface{}, error) { //nolint:funlen
+	if om == nil || om.list == nil {
+		return []byte("null"), nil
+	}
+
+	node := yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+		key, value := pair.Key, pair.Value
+
+		keyNode := &yaml.Node{}
+
+		// serialize key to yaml, then unserialize it back into the node
+		// this is a hack to get the correct tag for the key
+
+		if err := keyNode.Encode(key); err != nil {
+			return nil, err
+		}
+
+		valueNode := &yaml.Node{}
+		if err := valueNode.Encode(value); err != nil {
+			return nil, err
+		}
+
+		node.Content = append(node.Content, keyNode, valueNode)
+	}
+
+	return &node, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (om *OrderedMap[K, V]) UnmarshalYAML(value *yaml.Node) error {
+	if om.list == nil {
+		om.initialize(0)
+	}
+
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("pipeline must contain YAML mapping, has %v", value.Kind)
+	}
+	for i := 0; i < len(value.Content); i += 2 {
+		var key K
+		var val V
+
+		if err := value.Content[i].Decode(&key); err != nil {
+			return err
+		}
+		if err := value.Content[i+1].Decode(&val); err != nil {
+			return err
+		}
+
+		om.Set(key, val)
+	}
+
+	return nil
+}

--- a/yaml.go
+++ b/yaml.go
@@ -2,6 +2,7 @@ package orderedmap
 
 import (
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 )
 
@@ -12,7 +13,7 @@ var (
 
 // MarshalYAML implements the yaml.Marshaler interface.
 func (om *OrderedMap[K, V]) MarshalYAML() (interface{}, error) { //nolint:funlen
-	if om == nil || om.list == nil {
+	if om == nil {
 		return []byte("null"), nil
 	}
 
@@ -48,6 +49,8 @@ func (om *OrderedMap[K, V]) UnmarshalYAML(value *yaml.Node) error {
 	if om.list == nil {
 		om.initialize(0)
 	}
+
+	log.Info().Msgf("UnmarshalYAML: %v", value)
 
 	if value.Kind != yaml.MappingNode {
 		return fmt.Errorf("pipeline must contain YAML mapping, has %v", value.Kind)

--- a/yaml_fuzz_test.go
+++ b/yaml_fuzz_test.go
@@ -1,0 +1,81 @@
+package orderedmap
+
+// Adapted from https://github.com/dvyukov/go-fuzz-corpus/blob/c42c1b2/json/json.go
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func FuzzRoundTripYAML(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		for _, testCase := range []struct {
+			name        string
+			constructor func() any
+			// should be a function that asserts that 2 objects of the type returned by constructor are equal
+			equalityAssertion func(*testing.T, any, any) bool
+		}{
+			{
+				name:              "with a string -> string map",
+				constructor:       func() any { return &OrderedMap[string, string]{} },
+				equalityAssertion: assertOrderedMapsEqual[string, string],
+			},
+			{
+				name:              "with a string -> int map",
+				constructor:       func() any { return &OrderedMap[string, int]{} },
+				equalityAssertion: assertOrderedMapsEqual[string, int],
+			},
+			{
+				name:              "with a string -> any map",
+				constructor:       func() any { return &OrderedMap[string, any]{} },
+				equalityAssertion: assertOrderedMapsEqual[string, any],
+			},
+			{
+				name:              "with a struct with map fields",
+				constructor:       func() any { return new(testFuzzStruct) },
+				equalityAssertion: assertTestFuzzStructEqual,
+			},
+		} {
+			t.Run(testCase.name, func(t *testing.T) {
+				v1 := testCase.constructor()
+				if yaml.Unmarshal(data, v1) != nil {
+					return
+				}
+				t.Log(data)
+				t.Log(v1)
+
+				yamlData, err := yaml.Marshal(v1)
+				require.NoError(t, err)
+				t.Log(string(yamlData))
+
+				v2 := testCase.constructor()
+				err = yaml.Unmarshal(yamlData, v2)
+				if err != nil {
+					t.Log(string(yamlData))
+					t.Fatal(err)
+				}
+
+				if !assert.True(t, testCase.equalityAssertion(t, v1, v2), "failed with input data %q", string(data)) {
+					// look at that what the standard lib does with regular map, to help with debugging
+
+					var m1 map[string]any
+					require.NoError(t, yaml.Unmarshal(data, &m1))
+
+					mapJsonData, err := yaml.Marshal(m1)
+					require.NoError(t, err)
+
+					var m2 map[string]any
+					require.NoError(t, yaml.Unmarshal(mapJsonData, &m2))
+
+					t.Logf("initial data = %s", string(data))
+					t.Logf("unmarshalled map = %v", m1)
+					t.Logf("re-marshalled from map = %s", string(mapJsonData))
+					t.Logf("re-marshalled from test obj = %s", string(yamlData))
+					t.Logf("re-unmarshalled map = %s", m2)
+				}
+			})
+		}
+	})
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1,0 +1,318 @@
+package orderedmap
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestMarshalYAML(t *testing.T) {
+	t.Run("int key", func(t *testing.T) {
+		om := New[int, any]()
+		om.Set(1, "bar")
+		om.Set(7, "baz")
+		om.Set(2, 28)
+		om.Set(3, 100)
+		om.Set(4, "baz")
+		om.Set(5, "28")
+		om.Set(6, "100")
+		om.Set(8, "baz")
+		om.Set(8, "baz")
+		om.Set(9, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque auctor augue accumsan mi maximus, quis viverra massa pretium. Phasellus imperdiet sapien a interdum sollicitudin. Duis at commodo lectus, a lacinia sem.")
+
+		b, err := yaml.Marshal(om)
+
+		expected := `1: bar
+7: baz
+2: 28
+3: 100
+4: baz
+5: "28"
+6: "100"
+8: baz
+9: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque auctor augue accumsan mi maximus, quis viverra massa pretium. Phasellus imperdiet sapien a interdum sollicitudin. Duis at commodo lectus, a lacinia sem.
+`
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(b))
+	})
+
+	t.Run("string key", func(t *testing.T) {
+		om := New[string, any]()
+		om.Set("test", "bar")
+		om.Set("abc", true)
+
+		b, err := yaml.Marshal(om)
+		assert.NoError(t, err)
+		expected := `test: bar
+abc: true
+`
+		assert.Equal(t, expected, string(b))
+	})
+
+	t.Run("typed string key", func(t *testing.T) {
+		type myString string
+		om := New[myString, any]()
+		om.Set("test", "bar")
+		om.Set("abc", true)
+
+		b, err := yaml.Marshal(om)
+		assert.NoError(t, err)
+		assert.Equal(t, `test: bar
+abc: true
+`, string(b))
+	})
+
+	t.Run("typed int key", func(t *testing.T) {
+		type myInt uint32
+		om := New[myInt, any]()
+		om.Set(1, "bar")
+		om.Set(7, "baz")
+		om.Set(2, 28)
+		om.Set(3, 100)
+		om.Set(4, "baz")
+
+		b, err := yaml.Marshal(om)
+		assert.NoError(t, err)
+		assert.Equal(t, `1: bar
+7: baz
+2: 28
+3: 100
+4: baz
+`, string(b))
+	})
+
+	t.Run("TextMarshaller key", func(t *testing.T) {
+		om := New[marshallable, any]()
+		om.Set(marshallable(1), "bar")
+		om.Set(marshallable(28), true)
+
+		b, err := yaml.Marshal(om)
+		assert.NoError(t, err)
+		assert.Equal(t, `'#1#': bar
+'#28#': true
+`, string(b))
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		om := New[string, any]()
+
+		b, err := yaml.Marshal(om)
+		assert.NoError(t, err)
+		assert.Equal(t, "{}\n", string(b))
+	})
+}
+
+func TestUnmarshallYAML(t *testing.T) {
+	t.Run("int key", func(t *testing.T) {
+		data := `
+1: bar
+7: baz
+2: 28
+3: 100
+4: baz
+5: "28"
+6: "100"
+8: baz
+`
+		om := New[int, any]()
+		require.NoError(t, yaml.Unmarshal([]byte(data), &om))
+
+		assertOrderedPairsEqual(t, om,
+			[]int{1, 7, 2, 3, 4, 5, 6, 8},
+			[]any{"bar", "baz", 28, 100, "baz", "28", "100", "baz"})
+
+		// serialize back to yaml to make sure things are equal
+	})
+
+	t.Run("string key", func(t *testing.T) {
+		data := `{"test":"bar","abc":true}`
+
+		om := New[string, any]()
+		require.NoError(t, yaml.Unmarshal([]byte(data), &om))
+
+		assertOrderedPairsEqual(t, om,
+			[]string{"test", "abc"},
+			[]any{"bar", true})
+	})
+
+	t.Run("typed string key", func(t *testing.T) {
+		data := `{"test":"bar","abc":true}`
+
+		type myString string
+		om := New[myString, any]()
+		require.NoError(t, yaml.Unmarshal([]byte(data), &om))
+
+		assertOrderedPairsEqual(t, om,
+			[]myString{"test", "abc"},
+			[]any{"bar", true})
+	})
+
+	t.Run("typed int key", func(t *testing.T) {
+		data := `
+1: bar
+7: baz
+2: 28
+3: 100
+4: baz
+5: "28"
+6: "100"
+8: baz
+`
+		type myInt uint32
+		om := New[myInt, any]()
+		require.NoError(t, yaml.Unmarshal([]byte(data), &om))
+
+		assertOrderedPairsEqual(t, om,
+			[]myInt{1, 7, 2, 3, 4, 5, 6, 8},
+			[]any{"bar", "baz", 28, 100, "baz", "28", "100", "baz"})
+	})
+
+	t.Run("TextUnmarshaler key", func(t *testing.T) {
+		data := `{"#1#":"bar","#28#":true}`
+
+		om := New[marshallable, any]()
+		require.NoError(t, yaml.Unmarshal([]byte(data), &om))
+
+		assertOrderedPairsEqual(t, om,
+			[]marshallable{1, 28},
+			[]any{"bar", true})
+	})
+
+	t.Run("when fed with an input that's not an object", func(t *testing.T) {
+		for _, data := range []string{"true", `["foo"]`, "42", `"foo"`} {
+			om := New[int, any]()
+			require.Error(t, yaml.Unmarshal([]byte(data), &om))
+		}
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		data := `{}`
+
+		om := New[int, any]()
+		require.NoError(t, yaml.Unmarshal([]byte(data), &om))
+
+		assertLenEqual(t, om, 0)
+	})
+}
+
+func TestYAMLSpecialCharacters(t *testing.T) {
+	baselineMap := map[string]any{specialCharacters: specialCharacters}
+	baselineData, err := yaml.Marshal(baselineMap)
+	require.NoError(t, err) // baseline proves this key is supported by official yaml library
+	t.Logf("specialCharacters: %#v as []rune:%v", specialCharacters, []rune(specialCharacters))
+	t.Logf("baseline yaml data: %s", baselineData)
+
+	t.Run("marshal special characters", func(t *testing.T) {
+		om := New[string, any]()
+		om.Set(specialCharacters, specialCharacters)
+		b, err := yaml.Marshal(om)
+		require.NoError(t, err)
+		require.Equal(t, baselineData, b)
+
+		type myString string
+		om2 := New[myString, myString]()
+		om2.Set(specialCharacters, specialCharacters)
+		b, err = yaml.Marshal(om2)
+		require.NoError(t, err)
+		require.Equal(t, baselineData, b)
+	})
+
+	t.Run("unmarshall special characters", func(t *testing.T) {
+		om := New[string, any]()
+		require.NoError(t, yaml.Unmarshal(baselineData, &om))
+		assertOrderedPairsEqual(t, om,
+			[]string{specialCharacters},
+			[]any{specialCharacters})
+
+		type myString string
+		om2 := New[myString, myString]()
+		require.NoError(t, yaml.Unmarshal(baselineData, &om2))
+		assertOrderedPairsEqual(t, om2,
+			[]myString{specialCharacters},
+			[]myString{specialCharacters})
+	})
+}
+
+func TestYAMLRoundTrip(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		input         string
+		targetFactory func() any
+	}{
+		{
+			name: "",
+			input: `x: 28
+m:
+    bar:
+        - 5:
+            foo: bar
+    foo:
+        - 12:
+            b: true
+            i: 12
+            m:
+                a: b
+                c: 28
+            "n": null
+          28:
+            a: false
+            b:
+                - 1
+                - 2
+                - 3
+        - 3:
+            c: null
+            d: 87
+          4:
+            e: true
+          5:
+            f: 4
+            g: 5
+            h: 6
+`,
+			targetFactory: func() any { return &nestedMaps{} },
+		},
+		{
+			name:          "with UTF-8 special chars in key",
+			input:         "�: 0\n",
+			targetFactory: func() any { return &OrderedMap[string, int]{} },
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			target := testCase.targetFactory()
+
+			require.NoError(t, yaml.Unmarshal([]byte(testCase.input), target))
+
+			var (
+				out []byte
+				err error
+			)
+
+			out, err = yaml.Marshal(target)
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, testCase.input, string(out))
+			}
+		})
+	}
+}
+
+func BenchmarkMarshalYAML(b *testing.B) {
+	om := New[int, any]()
+	om.Set(1, "bar")
+	om.Set(7, "baz")
+	om.Set(2, 28)
+	om.Set(3, 100)
+	om.Set(4, "baz")
+	om.Set(5, "28")
+	om.Set(6, "100")
+	om.Set(8, "baz")
+	om.Set(8, "baz")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = yaml.Marshal(om)
+	}
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -94,8 +94,16 @@ abc: true
 `, string(b))
 	})
 
-	t.Run("empty map", func(t *testing.T) {
+	t.Run("empty map with 0 elements", func(t *testing.T) {
 		om := New[string, any]()
+
+		b, err := yaml.Marshal(om)
+		assert.NoError(t, err)
+		assert.Equal(t, "{}\n", string(b))
+	})
+
+	t.Run("empty map with no elements (null)", func(t *testing.T) {
+		om := &OrderedMap[string, string]{}
 
 		b, err := yaml.Marshal(om)
 		assert.NoError(t, err)
@@ -240,6 +248,13 @@ func TestYAMLRoundTrip(t *testing.T) {
 		input         string
 		targetFactory func() any
 	}{
+		{
+			name:  "empty map",
+			input: `{}`,
+			targetFactory: func() any {
+				return &OrderedMap[string, any]{}
+			},
+		},
 		{
 			name: "",
 			input: `x: 28


### PR DESCRIPTION
I've been using go-ordered-map for my go-go-golems ecosystem, 
and since most of the work I do is actually based on yaml, 
I decided to add ordered map serialization and deserialization from YAML.

I mostly copy-pasted the unit tests (and kept the JSON syntax for a fair amount of them).

The serialization and deserialization itself is very simple, as I basically just delegate
the marshalling to the underlying yaml.Node.

Fuzzing and unit tests all run.

- :sparkles: Add yaml/v3 implementation of ordered map deserialization
- :pencil: go fmt whitespace
- :art: Fix handling of empty map
- :umbrella: :sparkles: Add YAML fuzz test
