### PR TITLE
Add "Filter" function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/wk8/go-ordered-map/v2"
 )
@@ -72,6 +73,16 @@ func main() {
 	} // prints:
 	// coucou => toi
 	// bar => baz
+	
+	// removing all pairs which do not have an "o" in their key
+	om.Filter(func(key, value string) bool { return strings.Contains(key, "o") })
+	
+	// new iteration syntax
+	for key, value := range om.FromOldest() {
+		fmt.Printf("%s => %s\n", key, value)
+	}// prints:
+	// foo => bar
+	// coucou => toi
 }
 ```
 

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -371,3 +371,13 @@ func From[K comparable, V any](i iter.Seq2[K, V]) *OrderedMap[K, V] {
 
 	return oMap
 }
+
+func (om *OrderedMap[K, V]) Filter(predicate func (K, V) bool) {
+	for pair := om.Oldest(); pair != nil; {
+		key, value := pair.Key, pair.Value
+		pair = pair.Next()
+		if !predicate(key, value) {
+			om.Delete(key)
+		}
+	}
+}

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -496,3 +496,21 @@ func TestIteratorsFrom(t *testing.T) {
 	assert.Equal(t, expectedKeysFromNewest, keys)
 	assert.Equal(t, expectedValuesFromNewest, values)
 }
+
+func TestFilter(t *testing.T) {
+	om := New[int, int]()
+	
+	n := 10 * 3 // ensure divisibility by 3 for the length check below
+	for i := range n {
+		om.Set(i, i*i)
+	}
+	
+	om.Filter(func(k, v int) bool {
+		return k % 3 == 0
+	})
+	
+	assert.Equal(t, n / 3, om.Len())
+	for k := range om.FromOldest() {
+		assert.True(t, k%3==0)
+	}
+}


### PR DESCRIPTION
As noted in [an issue](https://github.com/wk8/go-ordered-map/issues/38), removing all elements from an OrderedMap except those that fulfill some criteria (known as "filtering" in functional contexts) is not straight-forward and contains a pitfall.

I have added a `Filter` function that is passed a predicate function and avoids this pitfall. The predicate function should return true if the key&value fit the criteria and should be kept and false otherwise, as may be familiar from other programming languages (e.g. python: [filter](https://docs.python.org/3/library/functions.html#filter))

Additionally I have added an example of this to the README. The new iteration syntax is now also showcased there.