### PR TITLE
feat: ✨  unmarshal into ordered maps

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -202,6 +202,21 @@ func TestUnmarshallJSON(t *testing.T) {
 
 		assertLenEqual(t, om, 0)
 	})
+
+	t.Run("nested maps become ordered", func(t *testing.T) {
+		data := `{"foo":{"zebra":"z","apple":"a"}}`
+
+		om := New[string, any]()
+		require.NoError(t, json.Unmarshal([]byte(data), &om))
+
+		expected := New[string, any]()
+		expected.Set("zebra", "z")
+		expected.Set("apple", "a")
+
+		got, ok := om.Get("foo")
+		require.True(t, ok)
+		assert.Equal(t, expected, got)
+	})
 }
 
 // const specialCharacters = "\\\\/\"\b\f\n\r\t\x00\uffff\ufffd世界\u007f\u00ff\U0010FFFF"

--- a/null.go
+++ b/null.go
@@ -1,0 +1,5 @@
+package orderedmap
+
+func JSONNullBytes() []byte {
+	return []byte("null")
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1,10 +1,11 @@
 package orderedmap
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 func TestMarshalYAML(t *testing.T) {
@@ -202,6 +203,21 @@ func TestUnmarshallYAML(t *testing.T) {
 
 		assertLenEqual(t, om, 0)
 	})
+
+	t.Run("unmarshals nests maps as ordered maps", func(t *testing.T) {
+		data := `{"foo":{"zebra":"z","apple":"a"}}`
+
+		om := New[string, any]()
+		require.NoError(t, yaml.Unmarshal([]byte(data), &om))
+
+		expected := New[string, any]()
+		expected.Set("zebra", "z")
+		expected.Set("apple", "a")
+
+		actual, ok := om.Get("foo")
+		require.True(t, ok)
+		require.Equal(t, expected, actual)
+	})
 }
 
 func TestYAMLSpecialCharacters(t *testing.T) {
@@ -264,6 +280,7 @@ m:
             foo: bar
     foo:
         - 12:
+            z: null
             b: true
             i: 12
             m:
@@ -277,8 +294,8 @@ m:
                 - 2
                 - 3
         - 3:
-            c: null
             d: 87
+            c: null
           4:
             e: true
           5:


### PR DESCRIPTION
this change will attempt to unmarshal `interface{}`/`any` values into an ordered map before falling back to default behavior

resolves #54